### PR TITLE
The storefront_primary_navigation action is responsible for the mobile menu

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -40,10 +40,11 @@ add_action('wp_enqueue_scripts', 'enqueue_custom_fonts');
 
 /**
  * Default menu of storefront is not sufficient. Hide for example the search
- * from the header and push everything on a single line.
+ * from the header and push everything on a single line. The action 
+ * storefront_primary_navigation is not removed as the mobile menu is 
+ * depending on that one.
  */
 function custom_header_layout(): void {
-    remove_action('storefront_header', 'storefront_primary_navigation', 50);
     remove_action('storefront_header', 'storefront_product_search', 40);
     remove_action('storefront_header', 'storefront_primary_navigation_wrapper', 42);
     remove_action('storefront_header', 'storefront_primary_navigation', 1);


### PR DESCRIPTION
When removing this action the mobile menu will not work.