### PR TITLE
Double declaration of storefront_handheld_footer_bar_search

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -129,17 +129,12 @@ function storefront_handheld_footer_bar(): void {
     <?php
 }
 
-	function storefront_handheld_footer_bar_search() {
-		echo '<a>' . esc_attr__( 'Search', 'storefront' ) . '</a>';
-		storefront_product_search();
-	}
-
 /**
  * Override the handheld search bar as the orignal source
  * includes an empty href which has a negative impact on
  * the SEO score of the site.
  */
-function storefront_handheld_footer_bar_search() {
+function storefront_handheld_footer_bar_search(): void {
 	echo '<a href="javascript:;">' . esc_attr__( 'Search', 'storefront' ) . '</a>';
 	storefront_product_search();
 }


### PR DESCRIPTION
Double declaration of storefront_handheld_footer_bar_search as an incorrect merge happened. Causing the website to error out when applying the latest version of the theme. Removing one of the storefront_handheld_footer_bar_search declarations as we do not need the other one.